### PR TITLE
Bump dask[complete] from 2024.10.0 to 2024.11.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ slack_sdk  # optional
 mplfinance==0.12.10b0  # optional
 
 # parallel computing
-dask[complete]==2024.10.0
+dask[complete]==2024.11.2
 
 # dev only
 pytest==8.3.3


### PR DESCRIPTION
Bumps [dask[complete]](https://github.com/dask/dask) from 2024.10.0 to 2024.11.2.
- [Release notes](https://github.com/dask/dask/releases)
- [Changelog](https://github.com/dask/dask/blob/main/docs/release-procedure.md)
- [Commits](https://github.com/dask/dask/compare/2024.10.0...2024.11.2)

---
updated-dependencies:
- dependency-name: dask[complete] dependency-type: direct:production update-type: version-update:semver-minor ...